### PR TITLE
Add make install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ You need X11, Qt and QML packages installed.
 
 ## Installing
 
-    install -D -m 0755 qvkbd "$pkgdir/usr/bin/qvkbd"
-    install -D -m 0755 qvkbd.desktop "$pkgdir/usr/share/applications/qvkbd.desktop"
-    install -D -m 0644 icons/keyboard.svg "$pkgdir/usr/share/icons/hicolor/scalable/qvkbd.svg"
+    sudo make install
 
 ## Usage
 

--- a/qvkbd.pro
+++ b/qvkbd.pro
@@ -52,3 +52,21 @@ DBUS_ADAPTORS += \
 
 DBUS_INTERFACES += \
 	src/xyz.etse.QVKbd.xml
+
+isEmpty( PREFIX ) {
+  PREFIX = /usr
+}
+
+# Install qvkbd binary
+target.path = $$PREFIX$$/bin
+INSTALLS += target
+
+# Install desktop file
+desktopfile.path  = $$PREFIX$$/share/applications/
+desktopfile.files = qvkbd.desktop
+INSTALLS += desktopfile
+
+# Install svg
+svgfile.path  = $$PREFIX$$/share/icons/hicolor/scalable/qvkbd.svg
+svgfile.files = icons/keyboard.svg
+INSTALLS += svgfile


### PR DESCRIPTION
Remove `install` commands from README.
Add qmake statements to install desktop file, svg file and binary via
`make install`.