### PR TITLE
X11Support: initialize m_running variable

### DIFF
--- a/src/x11support.cpp
+++ b/src/x11support.cpp
@@ -57,6 +57,7 @@ struct X11SupportPrivateData {
 
 X11Support::X11Support() {
 	m_privateData = new X11SupportPrivateData;
+	m_running = false;
 }
 
 X11Support::~X11Support() {


### PR DESCRIPTION
It would be safer to have it initialized as the thread is not running after the object is created.